### PR TITLE
Remove Italiano docs link

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -690,11 +690,6 @@ export default defineConfigWithTheme<ThemeConfig>({
         repo: 'https://github.com/vuejs-translations/docs-bn'
       },
       {
-        link: 'https://it.vuejs.org',
-        text: 'Italiano',
-        repo: 'https://github.com/vuejs-translations/docs-it'
-      },
-      {
         link: '/translations/',
         text: 'Aiutaci a tradurre!',
         isTranslationsDesc: true


### PR DESCRIPTION
## Description of Problem
![image](https://github.com/vuejs-translations/docs-it/assets/109757944/dc6d973c-bf3e-442f-943c-8c2a5d30721b)

## Proposed Solution
Removed the Italiano documentation link from the language menu since we are already in the Italian version.

## Additional Information
N/A